### PR TITLE
Display an error messages when miv unable to parse `~/.vimrc.yaml`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-3.15
+resolver: lts-6.7


### PR DESCRIPTION
Hi! This software is Interesting. but if `~/.vimrc.yaml` unable to parce. I can not found mistake.

For example,
itchyny/miv : master
`> miv: Parse error`

So I displaying error massage of Aeson.
eliza0x/miv: errorMsg
`> miv: Aeson exception:
Error in $.plugin['itchyny/vim-cursorword']: failed to parse field plugin: expected plugin, encountered Null`