### PR TITLE
Fix: using "sh -c" to make commands available in windows

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -29,7 +29,7 @@ lastUpdate :: FilePath -> IO Integer
 lastUpdate path = read <$> readProcess "sh" ["-c", unwords ["git", "-C", singleQuote path, "show", "-s", "--format=%ct", "2>/dev/null", "||", "echo", "0"]] []
 
 gitStatus :: FilePath -> IO ExitCode
-gitStatus path = system $ unwords ["git", "-C", singleQuote path, "status", ">/dev/null 2>&1"]
+gitStatus path = system $ unwords ["sh", "-c", "\"git", "-C", singleQuote path, "status", ">/dev/null 2>&1\""]
 
 gitUrl :: String -> String
 gitUrl = ("https://github.com/" <>)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -242,7 +242,7 @@ generateHelpTags setting = do
   P.forM_ (map (\p -> dir <> rtpName p <> "/doc/") (plugins setting)) $ \path -> do
     exists <- doesDirectoryExist path
     when exists $
-      void $ system $ unwords ["cd", "'" <> path <> "'", "&& cp *", "'" <> docdir <> "'", "2>/dev/null"]
+      void $ system $ unwords ["sh", "-c", "\"cd", "'" <> path <> "'", "&& cp *", "'" <> docdir <> "'", "2>/dev/null\""]
   _ <- system $ "vim -u NONE -i NONE -N -e -s -c 'helptags " <> docdir <> "' -c quit"
   putStrLn "Success in processing helptags."
 


### PR DESCRIPTION
Since git for windows pretty much is already required using `sh -c` when launching commands seems like the better solution for cross-platform as windows don't natively use `cp` or the same null device as Unix based systems.

This removes:
* Unneccessary stdout since windows can't find "/dev/null"
* helptag copying and building is working under windows

I'm sure there is a way to write this in a prettier format, but my Haskell knowledge is very limited.